### PR TITLE
Fix typo in removePathsFromEnvVariables.ps1 that delete the complete `Path` User variable

### DIFF
--- a/removePathsFromEnvVariables.ps1
+++ b/removePathsFromEnvVariables.ps1
@@ -13,7 +13,7 @@ $newVar = ($currVar.Split(';') | Where-Object { $_ -ne $installPrefix + '\debug'
 
 Write-Host 'Removing ' + $installPrefix + '\debug\bin from the Path User enviroment variable.'
 $currVar = [System.Environment]::GetEnvironmentVariable('Path', 'User');
-$newVar = ($curVarr.Split(';') | Where-Object { $_ -ne $installPrefix + '\debug\bin' }) -join ';';
+$newVar = ($currVar.Split(';') | Where-Object { $_ -ne $installPrefix + '\debug\bin' }) -join ';';
 [System.Environment]::SetEnvironmentVariable('Path', $newVar, 'User');
 
 Write-Host 'Removing ' + $installPrefix + '\bin from the Path User enviroment variable.'


### PR DESCRIPTION
**CRITICAL BUG FIX**

Without this fix, during the uninstall the `Path` user variable was completely removed, instead of just removing the values added during the install.